### PR TITLE
Fix ISO creation error due to missing mtools dependency

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -25,6 +25,7 @@ jobs:
             grub-pc-bin \
             grub-common \
             xorriso \
+            mtools \
             make
 
       - name: Build kernel and ISO

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -18,7 +18,7 @@ sudo apt install build-essential
 sudo apt install gcc-multilib
 
 # GRUB and ISO creation
-sudo apt install grub-pc-bin grub-common xorriso
+sudo apt install grub-pc-bin grub-common xorriso mtools
 
 # Emulation
 sudo apt install qemu-system-x86
@@ -465,7 +465,7 @@ sudo apt install gcc-multilib libc6-dev-i386
 
 **Error: grub-mkrescue not found**
 ```bash
-sudo apt install grub-pc-bin grub-common xorriso
+sudo apt install grub-pc-bin grub-common xorriso mtools
 ```
 
 **Error: undefined reference to `__stack_chk_fail`**
@@ -572,7 +572,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt update
-        sudo apt install -y gcc-multilib grub-pc-bin xorriso
+        sudo apt install -y gcc-multilib grub-pc-bin xorriso mtools
     
     - name: Build
       run: make all

--- a/makefile
+++ b/makefile
@@ -275,14 +275,14 @@ iso: build/kernel.bin build
 
 bengaltiger.iso: iso
 	@echo "Creating bootable ISO..."
-	@if command -v grub-mkrescue >/dev/null 2>&1; then \
+	@if command -v grub-mkrescue >/dev/null 2>&1 && command -v mformat >/dev/null 2>&1; then \
 		grub-mkrescue -o bengaltiger.iso iso; \
 	elif command -v xorriso >/dev/null 2>&1; then \
 		xorriso -as mkisofs -o bengaltiger.iso -c boot.cat \
 			-b boot/grub/i386-pc/eltorito.img -no-emul-boot \
 			-boot-load-size 4 -boot-info-table iso; \
 	else \
-		echo "WARNING: grub-mkrescue or xorriso not found. ISO not created."; \
+		echo "WARNING: grub-mkrescue (with mtools) or xorriso not found. ISO not created."; \
 		echo "Kernel binary is available at build/kernel.bin"; \
 	fi
 


### PR DESCRIPTION
This PR fixes a build failure where `grub-mkrescue` was failing because `mtools` (specifically `mformat`) was missing. 

Changes:
1.  **Documentation**: Updated `docs/BUILD.md` to include `mtools` in the Toolchain Requirements and Troubleshooting sections for Linux.
2.  **Build System**: Modified the `makefile` to check for the presence of `mformat` before attempting to use `grub-mkrescue`. This allows the build system to provide a better warning or fall back to `xorriso` if `grub-mkrescue`'s dependencies are incomplete.
3.  **CI**: Updated the example GitHub Actions workflow in `docs/BUILD.md` to include `mtools`.

Verified by running `make all` in a clean environment after installing `mtools`.

---
*PR created automatically by Jules for task [11457288710569648095](https://jules.google.com/task/11457288710569648095) started by @mahmud-r-farhan*